### PR TITLE
fix: adjust header button for mobile

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -42,16 +42,16 @@ const Header = () => {
 					{/* Условная отрисовка кнопки "Подробнее" для мобильных устройств */}
 					{/* placeholder for additional actions */}
 
-					{/* Условная отрисовка текста на кнопке "Заказать" в зависимости от разрешения */}
-                                        <Button
-                                                className='py-4 sm:text-sm md:text-base lg:text-lg ml-3'
-                                                type='primary'
-                                                shape='round'
-                                                size='large'
-                                                onClick={() => setIsModalOpen(true)}
-                                        >
-                                                Получить гайд
-                                        </Button>
+                                       {/* Условная отрисовка текста на кнопке "Заказать" в зависимости от разрешения */}
+                                       <Button
+                                               className='px-4 py-2 text-sm sm:text-sm md:text-base lg:text-lg ml-0 sm:ml-3'
+                                               type='primary'
+                                               shape='round'
+                                               size={isMobile ? 'middle' : 'large'}
+                                               onClick={() => setIsModalOpen(true)}
+                                       >
+                                               Получить гайд
+                                       </Button>
 					<OrderModal
 						open={isModalOpen}
 						onClose={() => setIsModalOpen(false)}


### PR DESCRIPTION
## Summary
- tweak header button padding and margin for small screens
- set responsive button size to keep layout within mobile viewport

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Poppins` font)*

------
https://chatgpt.com/codex/tasks/task_e_68c276aa067c8327b5069e2b1bb5e90a