### PR TITLE
Add robots & sitemap and move VK pixel to head

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://ip.ru/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://ip.ru/</loc>
+  </url>
+</urlset>

--- a/src/app/VKMetrika.tsx
+++ b/src/app/VKMetrika.tsx
@@ -3,12 +3,11 @@
 import Script from 'next/script'
 
 export const VKMetrika = () => (
-	<>
-		<Script
-			id='vk-metrika'
-			strategy='afterInteractive'
-			dangerouslySetInnerHTML={{
-				__html: `
+        <Script
+                id='vk-metrika'
+                strategy='beforeInteractive'
+                dangerouslySetInnerHTML={{
+                        __html: `
 var _tmr = window._tmr || (window._tmr = []);
 _tmr.push({id: "3692734", type: "pageView", start: (new Date()).getTime()});
 (function (d, w, id) {
@@ -19,18 +18,20 @@ _tmr.push({id: "3692734", type: "pageView", start: (new Date()).getTime()});
   if (w.opera == "[object Opera]") { d.addEventListener("DOMContentLoaded", f, false); } else { f(); }
 })(document, window, "tmr-code");
         `
-			}}
-		/>
-		<noscript>
-			<div>
-				<img
-					src='https://top-fwz1.mail.ru/counter?id=3692734;js=na'
-					style={{ position: 'absolute', left: '-9999px' }}
-					alt='Top.Mail.Ru'
-				/>
-			</div>
-		</noscript>
-	</>
+                }}
+        />
+)
+
+export const VKMetrikaNoScript = () => (
+        <noscript>
+                <div>
+                        <img
+                                src='https://top-fwz1.mail.ru/counter?id=3692734;js=na'
+                                style={{ position: 'absolute', left: '-9999px' }}
+                                alt='Top.Mail.Ru'
+                        />
+                </div>
+        </noscript>
 )
 
 export default VKMetrika

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Poppins } from "next/font/google";
 import "./globals.css";
 import AntdProvider from "./AntdRegistry";
-import { VKMetrika } from './VKMetrika'
+import { VKMetrika, VKMetrikaNoScript } from './VKMetrika'
 
 const poppins = Poppins({
   subsets: ["latin-ext"],
@@ -26,11 +26,14 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-		<html lang='ru'>
-			<body className={poppins.className}>
+                <html lang='ru'>
+                        <head>
                                 <VKMetrika />
+                        </head>
+                        <body className={poppins.className}>
+                                <VKMetrikaNoScript />
                                 <AntdProvider>{children}</AntdProvider>
-			</body>
-		</html>
+                        </body>
+                </html>
   )
 }


### PR DESCRIPTION
## Summary
- add `robots.txt` and `sitemap.xml` for search engines
- move VK pixel script to `<head>` with a noscript fallback

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2850d5f748327a22ae4a9973be24c