### PR TITLE
feat: add Yandex Metrika analytics

### DIFF
--- a/src/app/YandexMetrika.tsx
+++ b/src/app/YandexMetrika.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import Script from 'next/script'
+
+export const YandexMetrika = () => (
+	<Script
+		id='yandex-metrika'
+		strategy='beforeInteractive'
+		dangerouslySetInnerHTML={{
+			__html: `
+(function(m,e,t,r,i,k,a){
+    m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)}
+    m[i].l=1*new Date()
+    for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
+    k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)
+})(window, document,'script','https://mc.yandex.ru/metrika/tag.js?id=104139431', 'ym');
+
+ym(104139431, 'init', {ssr:true, webvisor:true, clickmap:true, ecommerce:"dataLayer", accurateTrackBounce:true, trackLinks:true});
+        `
+		}}
+	/>
+)
+
+export const YandexMetrikaNoScript = () => (
+	<noscript>
+		<div>
+			<img
+				src='https://mc.yandex.ru/watch/104139431'
+				style={{ position: 'absolute', left: '-9999px' }}
+				alt=''
+			/>
+		</div>
+	</noscript>
+)
+
+export default YandexMetrika

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,39 +1,41 @@
-import type { Metadata } from "next";
-import { Poppins } from "next/font/google";
-import "./globals.css";
-import AntdProvider from "./AntdRegistry";
+import type { Metadata } from 'next'
+import { Poppins } from 'next/font/google'
+import './globals.css'
+import AntdProvider from './AntdRegistry'
 import { VKMetrika, VKMetrikaNoScript } from './VKMetrika'
+import { YandexMetrika, YandexMetrikaNoScript } from './YandexMetrika'
 
 const poppins = Poppins({
-  subsets: ["latin-ext"],
-  weight: ["400", "500", "600", "700"],
-  variable: "--font-poppins",
-});
+	subsets: ['latin-ext'],
+	weight: ['400', '500', '600', '700'],
+	variable: '--font-poppins'
+})
 
 export const metadata: Metadata = {
-        title: '0→1',
-        description:
-                'Платформа и комьюнити для новых ИП: шаги после регистрации, налоги и первые клиенты.',
-        icons: {
-                icon: 'image.png'
-        }
+	title: '0→1',
+	description:
+		'Платформа и комьюнити для новых ИП: шаги после регистрации, налоги и первые клиенты.',
+	icons: {
+		icon: 'image.png'
+	}
 }
 
-
 export default function RootLayout({
-  children,
+	children
 }: Readonly<{
-  children: React.ReactNode;
+	children: React.ReactNode
 }>) {
-  return (
-                <html lang='ru'>
-                        <head>
-                                <VKMetrika />
-                        </head>
-                        <body className={poppins.className}>
-                                <VKMetrikaNoScript />
-                                <AntdProvider>{children}</AntdProvider>
-                        </body>
-                </html>
-  )
+	return (
+		<html lang='ru'>
+			<head>
+				<VKMetrika />
+				<YandexMetrika />
+			</head>
+			<body className={poppins.className}>
+				<VKMetrikaNoScript />
+				<YandexMetrikaNoScript />
+				<AntdProvider>{children}</AntdProvider>
+			</body>
+		</html>
+	)
 }


### PR DESCRIPTION
## Summary
- add Yandex.Metrika counter component
- include Yandex and VK analytics in root layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c52435bf6483278eaaf9dac30b724d